### PR TITLE
Fix debian buster linker problem

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ add_link_options(${FRIDA_LINKER_FLAGS})
 
 add_executable(test_mocxx ${TEST_FILES})
 
-target_link_libraries(test_mocxx ${FRIDA_LIBRARIES})
+target_link_libraries(test_mocxx ${FRIDA_LIBRARIES} stdc++fs)
 
 add_test(NAME test_mocxx COMMAND test_mocxx)
 


### PR DESCRIPTION
It seems debian busters clang requires this change to the CMakeLists.txt file to link correctly.

I have set clang via update-alternatives and changed this file, then it worked.

I also installed clang-11 backport to buster but if I interpret cmake output correctly it used the normal system version of clang 7.0.1..

All of this may be obsolete with the next debian stable version appearing in about a week I think, so it may be reasonable to ignore this pull request if the new debian release fixes this and this pull request may cause other problems down the line (though I don't see why it should).